### PR TITLE
Update Region.vue

### DIFF
--- a/src/Region.vue
+++ b/src/Region.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <span v-if="!ui && text">
-            {{itemProvince&&itemProvince.value}}{{itemCity&&itemCity.value}}{{itemArea&&itemArea.value}}{{itemTown&&itemTown.value}}
+            {{itemProvince&&itemProvince.value}}{{textSeparator}}{{itemCity&&itemCity.value}}{{textSeparator}}{{itemArea&&itemArea.value}}{{textSeparator}}{{itemTown&&itemTown.value}}
         </span>
 
 
@@ -119,6 +119,10 @@
             text: {
                 type: Boolean,
                 default: false
+            },
+            textSeparator: {
+                type: String,
+                default: ''
             }
         },
         data(){


### PR DESCRIPTION
text	Boolean	初始化的区域信息以纯文本形式展示，适用于非表单场景

实际应用中有一些场景需要有分隔符的显示，比如：宁波市 鄞州区 首南西路 或 宁波市，鄞州区，首南西路 甚至是更为复杂的东西，
本次提交增加了一个参数：textSeparator，可使用户方面的自定义分隔符。

未来甚至可以让textSeparator 直接html输出，以支持用户定义dom结构类型的分隔符(可能并无使用场景)。